### PR TITLE
ensure that config files don't get cleaned up prematurely

### DIFF
--- a/lib/vagrant-ohai/action_configure_chef.rb
+++ b/lib/vagrant-ohai/action_configure_chef.rb
@@ -9,7 +9,6 @@ module VagrantPlugins
         @app = app
         @env = env
         @machine = env[:machine]
-        @tempfiles = []
         register_custom_chef_config
       end
 
@@ -23,8 +22,6 @@ module VagrantPlugins
         tmp.puts 'Ohai::Config[:plugin_path] << "/etc/chef/ohai_plugins"'
         tmp.write(File.read(current_conf)) if current_conf
         tmp.close
-        # retain a reference to prevent tempfile from being auto cleaned up
-        @tempfiles << tmp
         tmp
       end
 
@@ -38,6 +35,8 @@ module VagrantPlugins
           end
           custom_config = ohai_custom_config(current_custom_config_path)
           provisioner.config.instance_variable_set("@custom_config_path", custom_config.path)
+          # retain a reference to prevent tempfile from being auto cleaned up
+          provisioner.config.instance_variable_set("@__custom_config_tempfile__", custom_config)
         end
       end
     end


### PR DESCRIPTION
Add a reference to the tempfile on the same config object that has the path to ensure that the underlying file will have the same lifetime as the reference to it. Without this config files get cleaned up prematurely, causing failures, when using the [vsphere](https://github.com/nsidc/vagrant-vsphere) provider.