### PR TITLE
Use provisioner type instead of name

### DIFF
--- a/lib/vagrant-ohai/helpers.rb
+++ b/lib/vagrant-ohai/helpers.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
     module Helpers
       def chef_provisioners
         @machine.config.vm.provisioners.find_all do |provisioner|
-          [:shell, :chef_client, :chef_solo, :chef_zero, :chef_apply].include? provisioner.name
+          [:shell, :chef_client, :chef_solo, :chef_zero, :chef_apply].include? provisioner.type
         end
       end
     end


### PR DESCRIPTION
I've been running into some issues using this plugin. After some debugging, I determined that the helper method `chef_provisioners` was returning false despite the configuration being managed by `:chef_zero`. After putting some print statements in, I came to find that `provisioner.name` was empty and that `provisioner.type` appeared to have the intended value. I checked the [vagrant documentation](https://github.com/mitchellh/vagrant/blob/master/plugins/kernel_v2/config/vm_provisioner.rb) and `provisioner.name` is documented as being a string whereas `provisioner.type` is documented as being a symbol.