### PR TITLE
Remove unnecessary restrictions

### DIFF
--- a/lib/ohai/vagrant.rb
+++ b/lib/ohai/vagrant.rb
@@ -47,19 +47,17 @@ Ohai.plugin(:VboxIpaddress) do
 
       # requested nit
       nic = vagrant['primary_nic']
-      if etc['passwd'].keys.include?('vagrant') && virtualization['system'] == 'vbox'
-        if nic
-          nic, addr = lookup_address_by_nic(network, nic)
-        elsif vagrant['private_ipv4']
-          nic, addr = lookup_address_by_ipaddress(network, vagrant['private_ipv4'])
-        else
-          nic, addr = nil, nil
-          Ohai::Log.info("Neither nic nor private_ipv4 are set, skipping")
-        end
-        if addr
-          Ohai::Log.info("Ohai override :ipaddress to #{addr} from #{nic}")
-          ipaddress addr
-        end
+      if nic
+        nic, addr = lookup_address_by_nic(network, nic)
+      elsif vagrant['private_ipv4']
+        nic, addr = lookup_address_by_ipaddress(network, vagrant['private_ipv4'])
+      else
+        nic, addr = nil, nil
+        Ohai::Log.info("Neither nic nor private_ipv4 are set, skipping")
+      end
+      if addr
+        Ohai::Log.info("Ohai override :ipaddress to #{addr} from #{nic}")
+        ipaddress addr
       end
     end
   end


### PR DESCRIPTION
Maybe I have missed something but I don't think there is a need at all to check if there is a vagrant user and that the machine is a VirtualBox VM.

First of all, this is a Vagrant plugin. It gets executed by Vagrant. It does not get executed without Vagrant.

Secondly, Vagrant supports multiple providers. VirtualBox is just one of them and happens to be the default one. This plugin would also work for e.g. the VMWare provider. I don't see the need for excluding those alternative providers.

Thirdly, the vagrant user is the default user but Vagrant itself is flexible enough to allow another user to be the default user by modifying the config.ssh options in the Vagrantfile. E.g. I have an image generated by Packer where the user is someone else. The vagrant user does not even exist.