### PR TITLE
add support for custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ If you wish to use a primary nic which is not a private network, e.g. when using
 
     config.ohai.primary_nic = "eth1"
 
+To activate custom plugin support put `config.ohai.plugins_dir = <full_path_to_plugins_dir>` in your Vagrantfile
+
+    config.ohai.plugins_dir = "/var/ohai/custom_plugins"
+
 ## Compatibility
 
 This plugin works with Vagrant 1.2.3 and above.

--- a/lib/vagrant-ohai/action_configure_chef.rb
+++ b/lib/vagrant-ohai/action_configure_chef.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
       end
 
       def register_custom_chef_config
-        return unless @machine.config.ohai.enable
+        return unless @machine.config.ohai.enable or @machine.config.ohai.plugins_dir
         chef_provisioners.each do |provisioner|
           if provisioner.config.respond_to? :custom_config_path and not provisioner.config.custom_config_path == Plugin::UNSET_VALUE
             current_custom_config_path = provisioner.config.custom_config_path

--- a/lib/vagrant-ohai/action_install_ohai_plugin.rb
+++ b/lib/vagrant-ohai/action_install_ohai_plugin.rb
@@ -23,6 +23,11 @@ module VagrantPlugins
           create_ohai_folders
           copy_ohai_plugin
         end
+        if is_chef_used && @machine.config.ohai.plugins_dir
+          @machine.ui.info("Installing Custom Ohai plugin")
+          create_ohai_folders
+          copy_ohai_custom_plugins
+        end
       end
 
       private
@@ -56,6 +61,15 @@ module VagrantPlugins
         @machine.communicate.upload(hint_file.path, "/etc/chef/ohai_plugins/vagrant.json")
 
         @machine.communicate.upload(OHAI_PLUGIN_PATH, "/etc/chef/ohai_plugins/vagrant.rb")
+      end
+
+      def copy_ohai_custom_plugins
+
+        files = Dir.entries(@machine.config.ohai.plugins_dir).select { |e| e =~ /^[a-z]+\.rb/ }
+        files.each do |file|
+          custom_ohai_plugin_path = File.expand_path("#{@machine.config.ohai.plugins_dir}/#{file}", __FILE__)
+          @machine.communicate.upload(custom_ohai_plugin_path, "/etc/chef/ohai_plugins/#{file}")
+        end
       end
 
     end

--- a/lib/vagrant-ohai/config.rb
+++ b/lib/vagrant-ohai/config.rb
@@ -3,14 +3,17 @@ module VagrantPlugins
     class Config < Vagrant.plugin(2, :config)
       attr_accessor :enable
       attr_accessor :primary_nic
+      attr_accessor :plugins_dir
 
       def initialize
         @enable = UNSET_VALUE
         @primary_nic = UNSET_VALUE
+        @plugins_dir = UNSET_VALUE
       end
       def finalize!
         @enable = true if @enable == UNSET_VALUE
         @primary_nic = nil if @primary_nic == UNSET_VALUE
+        @plugins_dir = nil if @plugins_dir == UNSET_VALUE
       end
 
       def validate(machine)
@@ -27,6 +30,16 @@ module VagrantPlugins
           {}
         else
           {"enable" => ["enable must be true or false"] }
+        end
+        case @plugins_dir
+        when nil
+          {}
+        else
+          if !File.directory?(@plugins_dir.to_s) or @plugins_dir.to_s !~ /^\//
+            {"plugins_dir" => ["plugins_dir must be an absolute path to a folder"]}
+          else
+            {}
+          end
         end
       end
 


### PR DESCRIPTION
I added a config option that if set will copy all of the .rb files from the directory as custom plugins.

works also with the enable set to false if the plugins_dir is set to a valid folder