### PR TITLE
change action_configure_chef timing

### DIFF
--- a/lib/vagrant-ohai/vagrant-ohai.rb
+++ b/lib/vagrant-ohai/vagrant-ohai.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         require_relative 'action_install_ohai_plugin'
         require_relative 'action_configure_chef'
         hook.after(Vagrant::Action::Builtin::Provision, ActionInstallOhaiPlugin)
-        hook.before(Vagrant::Action::Builtin::ConfigValidate, ActionConfigureChef)
+        hook.before(Vagrant::Action::Builtin::Provision, ActionConfigureChef)
       end
 
       config(:ohai) do


### PR DESCRIPTION
When the vagrant box used is downloaded on the 'vagrant up' the chef custom config is not being generated.
To fix this we change the timing of the ConfigureChef action to run before Provision instead of before ConfigValidate.