### PR TITLE
Support predictable network interface names (enp#s#) for primary_nic …

### DIFF
--- a/lib/vagrant-ohai/config.rb
+++ b/lib/vagrant-ohai/config.rb
@@ -20,6 +20,8 @@ module VagrantPlugins
         case @primary_nic
         when /eth[0-9]+/
             {}
+        when /enp[0-9]+s[0-9]+/
+            {}
         when nil
             {}
         else


### PR DESCRIPTION
With predictable network interface names, the pattern is no longer eth[0-9]+.
I have added support for the new pattern to primary_nic parameter.